### PR TITLE
Use default_factory for mutable pydantic defaults

### DIFF
--- a/src/kimera/server.py
+++ b/src/kimera/server.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from typing import Any, Dict, List
 
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .ecoform import EcoFormStore, GrammarNode, OrthographyVector
 from .symbolic import Triple, detect_contradictions
@@ -19,8 +19,8 @@ vault = DualVault()
 class GrammarNodeModel(BaseModel):
     node_id: str
     label: str
-    children: List['GrammarNodeModel'] = []
-    features: Dict[str, Any] = {}
+    children: List['GrammarNodeModel'] = Field(default_factory=list)
+    features: Dict[str, Any] = Field(default_factory=dict)
 
     class Config:
         arbitrary_types_allowed = True
@@ -31,7 +31,7 @@ class OrthographyVectorModel(BaseModel):
     unicode_normal_form: str
     diacritic_profile: List[float]
     ligature_profile: List[float]
-    variant_flags: Dict[str, bool] = {}
+    variant_flags: Dict[str, bool] = Field(default_factory=dict)
 
 
 class CreateEcoFormRequest(BaseModel):


### PR DESCRIPTION
### **User description**
## Summary
- avoid shared mutable defaults in GrammarNodeModel and OrthographyVectorModel
- import Field from pydantic for safe default factories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964f63b4648327be795f681a8f6473


___

### **PR Type**
Bug fix


___

### **Description**
- Replace mutable default values with `Field(default_factory=...)`

- Import `Field` from pydantic for safe defaults

- Fix potential shared state issues in model classes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mutable defaults"] --> B["Field(default_factory=...)"]
  C["Import Field"] --> B
  B --> D["Safe model instances"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Fix mutable defaults in Pydantic models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/kimera/server.py

<ul><li>Import <code>Field</code> from pydantic module<br> <li> Replace <code>children: List = []</code> with <code>Field(default_factory=list)</code><br> <li> Replace <code>features: Dict = {}</code> with <code>Field(default_factory=dict)</code><br> <li> Replace <code>variant_flags: Dict = {}</code> with <code>Field(default_factory=dict)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/Obsolete_Kim_2/pull/12/files#diff-10253716c720ef5e12dff030769e08ff7be99f0e6df6bd1f5ad91c6e803bad3d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

