### PR TITLE
Use default_factory for mutable pydantic defaults

### DIFF
--- a/src/kimera/server.py
+++ b/src/kimera/server.py
@@ -3,9 +3,18 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import uuid4
 from typing import Any, Dict, List
+from copy import deepcopy
 
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+try:  # support both Pydantic v1 and v2
+    from pydantic import ConfigDict, field_validator
+    _PYDANTIC_V2 = True
+except ImportError:  # pragma: no cover - running on Pydantic v1
+    from pydantic import validator as field_validator  # type: ignore
+    ConfigDict = None  # type: ignore
+    _PYDANTIC_V2 = False
 
 from .ecoform import EcoFormStore, GrammarNode, OrthographyVector
 from .symbolic import Triple, detect_contradictions
@@ -19,11 +28,19 @@ vault = DualVault()
 class GrammarNodeModel(BaseModel):
     node_id: str
     label: str
-    children: List['GrammarNodeModel'] = []
-    features: Dict[str, Any] = {}
+    children: List['GrammarNodeModel'] = Field(default_factory=list)
+    features: Dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        arbitrary_types_allowed = True
+    if _PYDANTIC_V2:
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+    else:  # pragma: no cover - Pydantic v1
+        class Config:
+            arbitrary_types_allowed = True
+
+    @field_validator('features', **({'mode': 'after'} if _PYDANTIC_V2 else {'always': True}))
+    @classmethod
+    def copy_features(cls, v: Dict[str, Any] | None) -> Dict[str, Any]:
+        return deepcopy(v or {})
 
 
 class OrthographyVectorModel(BaseModel):
@@ -31,7 +48,19 @@ class OrthographyVectorModel(BaseModel):
     unicode_normal_form: str
     diacritic_profile: List[float]
     ligature_profile: List[float]
-    variant_flags: Dict[str, bool] = {}
+    variant_flags: Dict[str, bool] = Field(default_factory=dict)
+
+    @field_validator('variant_flags', **({'mode': 'after'} if _PYDANTIC_V2 else {'always': True}))
+    @classmethod
+    def copy_variant_flags(cls, v: Dict[str, bool] | None) -> Dict[str, bool]:
+        return deepcopy(v or {})
+
+
+# ensure forward refs resolve for self-referential children
+if _PYDANTIC_V2:
+    GrammarNodeModel.model_rebuild()
+else:  # pragma: no cover - Pydantic v1
+    GrammarNodeModel.update_forward_refs()
 
 
 class CreateEcoFormRequest(BaseModel):


### PR DESCRIPTION
### **User description**
## Summary
- avoid shared mutable defaults in GrammarNodeModel and OrthographyVectorModel
- deep-copy incoming dicts to prevent external mutations
- add Pydantic v1/v2 compatible config and validators
- rebuild GrammarNodeModel forward references to support child recursion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964f63b4648327be795f681a8f6473


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix mutable default arguments in Pydantic models

- Add deep-copy validators to prevent external mutations

- Implement Pydantic v1/v2 compatibility layer

- Rebuild forward references for recursive model support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mutable Defaults"] --> B["default_factory Fields"]
  C["External Mutations"] --> D["Deep-copy Validators"]
  E["Pydantic Versions"] --> F["Compatibility Layer"]
  G["Forward References"] --> H["Model Rebuild"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Fix Pydantic model defaults and compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/kimera/server.py

<ul><li>Replace mutable default arguments with <code>default_factory</code> in model fields<br> <li> Add Pydantic v1/v2 compatibility imports and configuration<br> <li> Implement deep-copy validators for dict fields to prevent mutations<br> <li> Add model rebuild/update_forward_refs for recursive model support</ul>


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/Obsolete_Kim_2/pull/14/files#diff-10253716c720ef5e12dff030769e08ff7be99f0e6df6bd1f5ad91c6e803bad3d">+35/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

